### PR TITLE
add allow_collisions arg

### DIFF
--- a/escapism.py
+++ b/escapism.py
@@ -14,7 +14,7 @@ import re
 import string
 import sys
 
-__version__ = '0.0.2'
+__version__ = '1.0.0'
 
 SAFE = set(string.ascii_letters + string.digits)
 ESCAPE_CHAR = '_'
@@ -36,22 +36,40 @@ def _escape_char(c, escape_char=ESCAPE_CHAR):
     return ''.join(buf)
 
 
-def escape(to_escape, safe=SAFE, escape_char=ESCAPE_CHAR):
+def escape(to_escape, safe=SAFE, escape_char=ESCAPE_CHAR, allow_collisions=False):
     """Escape a string so that it only contains characters in a safe set.
-    
+
     Characters outside the safe list will be escaped with _%x_,
     where %x is the hex value of the character.
+
+    If `allow_collisions` is True, occurrences of `escape_char`
+    in the input will not be escaped.
+
+    In this case, `unescape` cannot be used to reverse the transform
+    because occurrences of the escape char in the resulting string are ambiguous.
+    Only use this mode when:
+
+    1. collisions cannot occur or do not matter, and
+    2. unescape will never be called.
+
+    .. versionadded: 1.0
+        allow_collisions argument.
+        Prior to 1.0, behavior was the same as allow_collisions=False (default).
+
     """
     if isinstance(to_escape, bytes):
         # always work on text
         to_escape = to_escape.decode('utf8')
-    
+
     if not isinstance(safe, set):
         safe = set(safe)
-    if escape_char in safe:
+
+    if allow_collisions:
+        safe.add(escape_char)
+    elif escape_char in safe:
         # escape char can't be in safe list
         safe.remove(escape_char)
-    
+
     chars = []
     for c in to_escape:
         if c in safe:

--- a/tests/test_escapism.py
+++ b/tests/test_escapism.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from escapism import escape, unescape
+from escapism import escape, unescape, SAFE
 
 text = type(u'')
 
@@ -38,4 +38,14 @@ def test_escape_custom_safe():
         u = unescape(e, escape_char=escape_char)
         assert u == s
 
-    
+def test_safe_escape_char():
+    escape_char = '-'
+    safe = SAFE.union({escape_char})
+    e = escape(escape_char, safe=safe, escape_char=escape_char)
+    assert e == '{}{:02X}'.format(escape_char, ord(escape_char))
+    u = unescape(e, escape_char=escape_char)
+    assert u == escape_char
+
+def test_allow_collisions():
+    escaped = escape('foo-bar ', escape_char='-', allow_collisions=True)
+    assert escaped == 'foo-bar-20'


### PR DESCRIPTION
allows preventing double-escape of escape_char for cases where it is known ahead of time that collisions on the safe char cannot occur.

This is only useful for one-way conversions because it is not reversible.